### PR TITLE
make disposeBag and propsEntry func public, to be able to write extensions for Connection

### DIFF
--- a/ReRxSwift/Connection.swift
+++ b/ReRxSwift/Connection.swift
@@ -128,7 +128,7 @@ public class Connection<State: StateType, Props, Actions>: StoreSubscriber {
     let mapDispatchToActions: (@escaping DispatchFunction) -> (Actions)
 
     /// RxSwift memory management.
-    let disposeBag = DisposeBag()
+    public let disposeBag = DisposeBag()
 
     /// Constructs a new `Connection` object. For examples see the class documentation
     /// above, or the code examples in
@@ -185,7 +185,7 @@ public class Connection<State: StateType, Props, Actions>: StoreSubscriber {
 
     // MARK: - Helper functions
 
-    private func propsEntry<T>(at keyPath: KeyPath<Props, T>,
+    public func propsEntry<T>(at keyPath: KeyPath<Props, T>,
                                isEqual: @escaping (T,T) -> Bool)
         -> Observable<T> {
         return self.props


### PR DESCRIPTION
Making at least the `disposeBag` public allows to write stuff like my fork (adds conformance to non-equatable types) as a simple pure additive extensions.
Additionally I suggest to make `propsEntry(at:isEqual:)` public as well to be able to reuse this part in the extension (and not having to copy it over).